### PR TITLE
Correct double calling of callback when using expired status

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ roombaAccessory.prototype = {
             this.log.warn('Using expired status');
 
             status = this.cache.get(OLD_STATUS);
-            callback(status.error, status);
+            return callback(status.error, status);
         }
 
         // roomba is dead


### PR DESCRIPTION
Fixes #39 

Simply missing a return of the cached status, which meant it would go on to call the callback again saying it had failed and triggering the error message:

```
This plugin threw an error from the characteristic 'Contact Sensor State': Unhandled error thrown inside read handler for characteristic: This callback function has already been called by someone else; it can only be called one time.. See https://git.io/JtMGR for more info.
```
